### PR TITLE
fix: iris-2156 completing all node 8/10 -> 12 refs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.idea/

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   },
   "devDependencies": {},
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=12.0.0",
+    "npm": ">=6.0.0"
   },
   "bin": "index.js",
   "scripts": {


### PR DESCRIPTION
No need to update other repos to use the later npm package created by these changes